### PR TITLE
Fixed importing PSIni Module

### DIFF
--- a/Scripts/Convert-VIAWIM2VHD.ps1
+++ b/Scripts/Convert-VIAWIM2VHD.ps1
@@ -1,7 +1,7 @@
 Param(
     [Parameter(mandatory=$True,HelpMessage="Name and path of Sourcefile.")]
     [ValidateNotNullOrEmpty()]
-    [ValidateScript({Test-Path $_ -PathType ‘Leaf’})] 
+    [ValidateScript({Test-Path $_ -PathType 'Leaf'})] 
     [string] 
     $Sourcefile,
 
@@ -159,7 +159,7 @@ Switch ($Disklayout){
         Write-Verbose "OSBoot Driveletter is now = $VHDVolumeBoot"
 
         #Apply Image
-        sleep 5
+        Start-Sleep 5
         $Exe = $DISMExe
         $Args = " /apply-Image /ImageFile:""$SourceFile"" /index:$Index /ApplyDir:$VHDVolume\"
         Invoke-Exe -Executable $Exe -Arguments $Args -SuccessfulReturnCode 0 -Verbose
@@ -173,7 +173,7 @@ Switch ($Disklayout){
         Write-Verbose "Disknumber is now $VHDDiskNumber"
 
         # Format VHDx
-        Initialize-Disk -Number $VHDDiskNumber –PartitionStyle GPT
+        Initialize-Disk -Number $VHDDiskNumber -PartitionStyle GPT
         $VHDDrive1 = New-Partition -DiskNumber $VHDDiskNumber -GptType '{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}' -Size 499MB 
         $VHDDrive1 | Format-Volume -FileSystem FAT32 -NewFileSystemLabel System -Confirm:$false -Verbose
         $VHDDrive2 = New-Partition -DiskNumber $VHDDiskNumber -GptType '{e3c9e316-0b5c-4db8-817d-f92df00215ae}' -Size 128MB
@@ -189,7 +189,7 @@ Switch ($Disklayout){
         Write-Verbose "OSBoot Driveletter is now = $VHDVolumeBoot"
 
         #Apply Image
-        sleep 5
+        Start-Sleep 5
         $Exe = $DISMExe
         $Args = " /apply-Image /ImageFile:""$SourceFile"" /index:$Index /ApplyDir:$VHDVolume\"
         Invoke-Exe -Executable $Exe -Arguments $Args -SuccessfulReturnCode 0 -Verbose
@@ -218,7 +218,7 @@ Switch ($Disklayout){
         Write-Verbose "OSDrive Driveletter is now = $VHDVolume"
 
         #Apply Image
-        sleep 5
+        Start-Sleep 5
         $Exe = $DISMExe
         $Args = " /apply-Image /ImageFile:""$SourceFile"" /index:$Index /ApplyDir:$VHDVolume\"
         Invoke-Exe -Executable $Exe -Arguments $Args -SuccessfulReturnCode 0 -Verbose    }
@@ -367,7 +367,7 @@ If ($PathtoPackagesFolder -like '')
             $Packges = Get-Childitem -Path $PathtoPackagesFolder -Filter *.cab
                 foreach ($Packge in $Packges)
                 {
-                    Add-WindowsPackage –Path $VHDVolume –PackagePath $Packge.Fullname
+                    Add-WindowsPackage -Path $VHDVolume -PackagePath $Packge.Fullname
 
                 }
 

--- a/Scripts/IMF-Build.ps1
+++ b/Scripts/IMF-Build.ps1
@@ -48,7 +48,7 @@ $XMLFile = "$RootPath\IMF.xml"
 $Global:writetoscreen = $true
 
 #Importing modules
-Import-Module PSINI -ErrorAction Stop -WarningAction Stop -Force
+Import-Module PSINI -ErrorAction Stop -WarningAction Stop -Force -MinimumVersion 2.0.5
 Write-Log -Message "Module IMFFunctions imported"
 Import-Module IMFFunctions -ErrorAction Stop -WarningAction Stop -Force
 Write-Log -Message "Module IMFFunctions imported"
@@ -98,7 +98,7 @@ if((Test-Path -Path $MDTImage) -eq $true){Write-Log -Message "Access to $MDTImag
 
 #Get TaskSequences
 Write-Log -Message "Get TaskSequences"
-$RefTaskSequenceIDs = (Get-ChildItem -Path "MDT:\Task Sequences\$($Settings.Settings.MDT.RefTaskSequenceFolderName)" | where Enable -EQ $true).ID
+$RefTaskSequenceIDs = (Get-ChildItem -Path "MDT:\Task Sequences\$($Settings.Settings.MDT.RefTaskSequenceFolderName)" | Where-Object Enable -EQ $true).ID
 if($RefTaskSequenceIDs.count -eq 0){
     Write-Log -Message "Sorry, could not find any TaskSequences to work with"
     Return "Fail"
@@ -108,7 +108,7 @@ Write-Log -Message "Found $($RefTaskSequenceIDs.count) TaskSequences to work on"
 
 #Get detailed info
 Write-Log -Message "Get detailed info about the task sequences"
-$Result = (Get-ChildItem -Path "MDT:\Task Sequences\$($Settings.Settings.MDT.RefTaskSequenceFolderName)" | where Enable -EQ $true)
+$Result = (Get-ChildItem -Path "MDT:\Task Sequences\$($Settings.Settings.MDT.RefTaskSequenceFolderName)" | Where-Object Enable -EQ $true)
 foreach($obj in ($Result | Select-Object ID,Name,Version)){
     $data = "$($obj.ID) $($obj.Name) $($obj.Version)"
     Write-Log -Message $data
@@ -350,11 +350,11 @@ Invoke-Command -ComputerName $($Settings.Settings.HyperV.Computername) -ScriptBl
     foreach($property in ($Data.content.properties) ){
         $Hash =  [ordered]@{ 
             Name = $($property.Name); 
-            PercentComplete = $($property.PercentComplete.’#text’); 
-            Warnings = $($property.Warnings.’#text’); 
-            Errors = $($property.Errors.’#text’); 
+            PercentComplete = $($property.PercentComplete.'#text'); 
+            Warnings = $($property.Warnings.'#text'); 
+            Errors = $($property.Errors.'#text'); 
             DeploymentStatus = $( 
-            Switch($property.DeploymentStatus.’#text’){ 
+            Switch($property.DeploymentStatus.'#text'){ 
                 1 { "Active/Running"} 
                 2 { "Failed"} 
                 3 { "Successfully completed"} 
@@ -370,8 +370,8 @@ Invoke-Command -ComputerName $($Settings.Settings.HyperV.Computername) -ScriptBl
             VMHost = $($property.VMHost.'#text');
             VMName = $($property.VMName.'#text');
             LastTime = $($property.LastTime.'#text') -replace "T"," ";
-            StartTime = $($property.StartTime.’#text’) -replace "T"," "; 
-            EndTime = $($property.EndTime.’#text’) -replace "T"," "; 
+            StartTime = $($property.StartTime.'#text') -replace "T"," "; 
+            EndTime = $($property.EndTime.'#text') -replace "T"," "; 
             }
         New-Object PSObject -Property $Hash
         }
@@ -396,7 +396,7 @@ Invoke-Command -ComputerName $($Settings.Settings.HyperV.Computername) -ScriptBl
                     Write-Output "Currently running VM's : $($RunningVMs.Name) at $(Get-Date)"
                 }
                 else{
-                    Get-MDTOData -MDTMonitorServer $MDTServer | Where-Object -Property Name -EQ -Value $RunningVM.Name | Select-Object Name,PercentComplete,Warnings,Errors,DeploymentStatus,StartTime,Lasttime | FT
+                    Get-MDTOData -MDTMonitorServer $MDTServer | Where-Object -Property Name -EQ -Value $RunningVM.Name | Select-Object Name,PercentComplete,Warnings,Errors,DeploymentStatus,StartTime,Lasttime | Format-Table
                 }
             }
             Start-Sleep -Seconds "30"
@@ -440,11 +440,11 @@ Invoke-Command -ComputerName $($Settings.Settings.HyperV.Computername) -ScriptBl
     foreach($property in ($Data.content.properties) ){
         $Hash =  [ordered]@{ 
             Name = $($property.Name); 
-            PercentComplete = $($property.PercentComplete.’#text’); 
-            Warnings = $($property.Warnings.’#text’); 
-            Errors = $($property.Errors.’#text’); 
+            PercentComplete = $($property.PercentComplete.'#text'); 
+            Warnings = $($property.Warnings.'#text'); 
+            Errors = $($property.Errors.'#text'); 
             DeploymentStatus = $( 
-            Switch($property.DeploymentStatus.’#text’){ 
+            Switch($property.DeploymentStatus.'#text'){ 
                 1 { "Active/Running"} 
                 2 { "Failed"} 
                 3 { "Successfully completed"} 
@@ -460,8 +460,8 @@ Invoke-Command -ComputerName $($Settings.Settings.HyperV.Computername) -ScriptBl
             VMHost = $($property.VMHost.'#text');
             VMName = $($property.VMName.'#text');
             LastTime = $($property.LastTime.'#text') -replace "T"," ";
-            StartTime = $($property.StartTime.’#text’) -replace "T"," "; 
-            EndTime = $($property.EndTime.’#text’) -replace "T"," "; 
+            StartTime = $($property.StartTime.'#text') -replace "T"," "; 
+            EndTime = $($property.EndTime.'#text') -replace "T"," "; 
             }
         New-Object PSObject -Property $Hash
         }
@@ -473,7 +473,7 @@ Invoke-Command -ComputerName $($Settings.Settings.HyperV.Computername) -ScriptBl
                     Write-Output "Currently running VM's : $($RunningVMs.Name) at $(Get-Date)"
                 }
                 else{
-                    Get-MDTOData -MDTMonitorServer $MDTServer | Where-Object -Property Name -EQ -Value $RunningVM.Name | Select-Object Name,PercentComplete,Warnings,Errors,DeploymentStatus,StartTime,Lasttime | FT
+                    Get-MDTOData -MDTMonitorServer $MDTServer | Where-Object -Property Name -EQ -Value $RunningVM.Name | Select-Object Name,PercentComplete,Warnings,Errors,DeploymentStatus,StartTime,Lasttime | Format-Table
                 }
             }
             Start-Sleep -Seconds "30"

--- a/Scripts/IMF-Configure.ps1
+++ b/Scripts/IMF-Configure.ps1
@@ -96,7 +96,7 @@ Write-Log -Message "Module IMFFunctions imported"
 if((Get-Module PSINI).name -ne "PSINI"){
     Install-Module PSINI -Force -SkipPublisherCheck -ErrorAction Stop
 }else{Update-Module PSINI -Force}
-Import-Module PsIni -ErrorAction Stop -WarningAction Stop -RequiredVersion 2.0.5
+Import-Module PsIni -ErrorAction Stop -WarningAction Stop -MinimumVersion 2.0.5
 Write-Log -Message "Module PsIni imported"
 
 #Importing ModuleMicrosoftDeploymentToolkit

--- a/Scripts/IMF-Display.ps1
+++ b/Scripts/IMF-Display.ps1
@@ -10,7 +10,7 @@ Import-Module IMFFunctions -ErrorAction Stop -WarningAction Stop -Force
 Write-Log -Message "Module IMFFunctions imported"
 
 #Install PSINI
-Import-Module PsIni -ErrorAction Stop -WarningAction Stop -RequiredVersion 2.0.5
+Import-Module PsIni -ErrorAction Stop -WarningAction Stop -MinimumVersion 2.0.5
 Write-Log -Message "Module PsIni imported"
 
 #Importing ModuleMicrosoftDeploymentToolkit

--- a/Scripts/IMF-ImportISO.ps1
+++ b/Scripts/IMF-ImportISO.ps1
@@ -118,7 +118,7 @@ foreach($item in $Result){
         $Template = "Client.xml"
     }
         
-    $item | select *
+    $item | Select-Object *
     $Name = "Ref $($item.ImageName) for $($OSFolder)"
     $ID = "$OSFolder-$($item.ImageIndex)"
     $OperatingSystemPath = "MDT:\Operating Systems\Msft\$($item.name)"

--- a/Scripts/IMF-Install.ps1
+++ b/Scripts/IMF-Install.ps1
@@ -49,7 +49,7 @@ Import-Module IMFFunctions -ErrorAction Stop -WarningAction Stop -Force
 Write-Log -Message "Module IMFFunctions imported"
 
 #Install PSINI
-Import-Module PsIni -ErrorAction Stop -WarningAction Stop -RequiredVersion 2.0.5
+Import-Module PsIni -ErrorAction Stop -WarningAction Stop -MinimumVersion 2.0.5
 Write-Log -Message "Module PsIni imported"
 
 #Importing ModuleMicrosoftDeploymentToolkit

--- a/Scripts/IMF-SCVMMImport.ps1
+++ b/Scripts/IMF-SCVMMImport.ps1
@@ -184,11 +184,3 @@ foreach ($item in $Result){
 
     }
 }
-
-
-
-}
-
-
-
-

--- a/Scripts/IMF-VerifyBuild.ps1
+++ b/Scripts/IMF-VerifyBuild.ps1
@@ -54,7 +54,7 @@ $XMLFile = "$RootPath\IMF.xml"
 $Global:writetoscreen = $true
 
 #Importing modules
-Import-Module PSINI -ErrorAction Stop -WarningAction Stop -Force
+Import-Module PSINI -ErrorAction Stop -WarningAction Stop -Force -MinimumVersion 2.0.5
 Write-Log -Message "Module PSINI imported"
 Import-Module IMFFunctions -ErrorAction Stop -WarningAction Stop -Force
 Write-Log -Message "Module IMFFunctions imported"
@@ -314,11 +314,11 @@ do
     foreach($property in ($Data.content.properties) ){
         $Hash =  [ordered]@{ 
             Name = $($property.Name); 
-            PercentComplete = $($property.PercentComplete.’#text’); 
-            Warnings = $($property.Warnings.’#text’); 
-            Errors = $($property.Errors.’#text’); 
+            PercentComplete = $($property.PercentComplete.'#text'); 
+            Warnings = $($property.Warnings.'#text'); 
+            Errors = $($property.Errors.'#text'); 
             DeploymentStatus = $( 
-            Switch($property.DeploymentStatus.’#text’){ 
+            Switch($property.DeploymentStatus.'#text'){ 
                 1 { "Active/Running"} 
                 2 { "Failed"} 
                 3 { "Successfully completed"} 
@@ -334,8 +334,8 @@ do
             VMHost = $($property.VMHost.'#text');
             VMName = $($property.VMName.'#text');
             LastTime = $($property.LastTime.'#text') -replace "T"," ";
-            StartTime = $($property.StartTime.’#text’) -replace "T"," "; 
-            EndTime = $($property.EndTime.’#text’) -replace "T"," "; 
+            StartTime = $($property.StartTime.'#text') -replace "T"," "; 
+            EndTime = $($property.EndTime.'#text') -replace "T"," "; 
             }
         New-Object PSObject -Property $Hash
         }
@@ -360,7 +360,7 @@ do
                     Write-Host "Currently running VM's : $($RunningVMs.Name) at $(Get-Date)"
                 }
                 else{
-                    Get-MDTOData -MDTMonitorServer $MDTServer | Where-Object -Property Name -EQ -Value $RunningVM.Name | Select-Object Name,PercentComplete,Warnings,Errors,DeploymentStatus,StartTime,Lasttime | FT
+                    Get-MDTOData -MDTMonitorServer $MDTServer | Where-Object -Property Name -EQ -Value $RunningVM.Name | Select-Object Name,PercentComplete,Warnings,Errors,DeploymentStatus,StartTime,Lasttime | Format-Table
                 }
             }
             Start-Sleep -Seconds "30"
@@ -409,11 +409,11 @@ $return = Invoke-Command -ComputerName $($Settings.Settings.HyperV.Computername)
     foreach($property in ($Data.content.properties) ){
         $Hash =  [ordered]@{ 
             Name = $($property.Name); 
-            PercentComplete = $($property.PercentComplete.’#text’); 
-            Warnings = $($property.Warnings.’#text’); 
-            Errors = $($property.Errors.’#text’); 
+            PercentComplete = $($property.PercentComplete.'#text'); 
+            Warnings = $($property.Warnings.'#text'); 
+            Errors = $($property.Errors.'#text'); 
             DeploymentStatus = $( 
-            Switch($property.DeploymentStatus.’#text’){ 
+            Switch($property.DeploymentStatus.'#text'){ 
                 1 { "Active/Running"} 
                 2 { "Failed"} 
                 3 { "Successfully completed"} 
@@ -429,8 +429,8 @@ $return = Invoke-Command -ComputerName $($Settings.Settings.HyperV.Computername)
             VMHost = $($property.VMHost.'#text');
             VMName = $($property.VMName.'#text');
             LastTime = $($property.LastTime.'#text') -replace "T"," ";
-            StartTime = $($property.StartTime.’#text’) -replace "T"," "; 
-            EndTime = $($property.EndTime.’#text’) -replace "T"," "; 
+            StartTime = $($property.StartTime.'#text') -replace "T"," "; 
+            EndTime = $($property.EndTime.'#text') -replace "T"," "; 
             }
         New-Object PSObject -Property $Hash
         }
@@ -442,7 +442,7 @@ $return = Invoke-Command -ComputerName $($Settings.Settings.HyperV.Computername)
                     Write-Output "Currently running VM's : $($RunningVMs.Name) at $(Get-Date)"
                 }
                 else{
-                    Get-MDTOData -MDTMonitorServer $MDTServer | Where-Object -Property Name -EQ -Value $RunningVM.Name | Select-Object Name,PercentComplete,Warnings,Errors,DeploymentStatus,StartTime,Lasttime | FT
+                    Get-MDTOData -MDTMonitorServer $MDTServer | Where-Object -Property Name -EQ -Value $RunningVM.Name | Select-Object Name,PercentComplete,Warnings,Errors,DeploymentStatus,StartTime,Lasttime | Format-Table
                 }
             }
             Start-Sleep -Seconds "30"


### PR DESCRIPTION
Modified all instances of import-module to specify a minimum version of 2.0.5.  This required either adding "-minimumVersion 2.0.5" or in a few cases replacing "-required version 2.0.5"

Also fixed some garbled charachters and replaced a number of aliases with full command names